### PR TITLE
autoboot.c : Fix support for ctrl + q to enter bootmenu

### DIFF
--- a/common/autoboot.c
+++ b/common/autoboot.c
@@ -220,7 +220,7 @@ static int __abortboot(int bootdelay)
 #endif
 
 #ifdef CONFIG_ARCH_ROCKCHIP
-	if (!IS_ENABLED(CONFIG_CONSOLE_DISABLE_CLI) && (ctrlc() || ctrlq())) {
+	if (!IS_ENABLED(CONFIG_CONSOLE_DISABLE_CLI) && ctrlc_or_q()) {
 		/* we press ctrl+c or ctrl+q? */
 #else
 	/*
@@ -238,7 +238,7 @@ static int __abortboot(int bootdelay)
 		/* delay 1000 ms */
 		ts = get_timer(0);
 		do {
-			if (ctrlc() || ctrlq()) {
+			if (ctrlc_or_q()) {
 				/* we got a ctrl+c or ctrl+q key press	*/
 				abort  = 1;	/* don't auto boot	*/
 				bootdelay = 0;	/* no more delay	*/

--- a/common/console.c
+++ b/common/console.c
@@ -695,6 +695,29 @@ int ctrlq(void)
 	return 0;
 }
 
+/* test if ctrl-q or ctrl-c was pressed */
+int ctrlc_or_q(void)
+{
+#ifndef CONFIG_SANDBOX
+	if ((!ctrlq_disabled || !ctrlc_disabled) && gd->have_console) {
+		if (tstc()) {
+			switch (getc()) {
+			case 0x11:		/* ^Q - Control Q */
+				ctrlq_was_pressed = ctrlq_disabled ? ctrlq_was_pressed : 1;
+				return 1;
+			case 0x03:		/* ^C - Control C */
+				ctrlc_was_pressed = ctrlc_disabled ? ctrlc_was_pressed : 1;
+				return 0;
+			default:
+				break;
+			}
+		}
+	}
+#endif
+
+	return 0;
+}
+
 /* Reads user's confirmation.
    Returns 1 if user's input is "y", "Y", "yes" or "YES"
 */

--- a/include/console.h
+++ b/include/console.h
@@ -26,6 +26,13 @@ void clear_ctrlq(void);	/* clear the Control-Q condition */
 int disable_ctrlq(int);	/* 1 to disable, 0 to enable Control-Q detect */
 
 /**
+ * ctrlc_or_q() - checks for both ctrl-q or ctrl-c
+ *
+ * Calling explicitly both ctrlq() & ctrlc() consumes the input for other.
+ */
+int ctrlc_or_q(void);
+
+/**
  * console_record_init() - set up the console recording buffers
  *
  * This should be called as soon as malloc() is available so that the maximum


### PR DESCRIPTION
Introduce a new `ctrlc_or_q()` function to check for both `Ctrl+C` and `Ctrl+Q` keypresses, replacing `ctrlc() || ctrlq()` checks in `autoboot.c`. The previous approach prematurely consuming input for other, preventing reliable detection of both keys.