### PR TITLE
usb: fix missing error assignment in ohci and clean up xhci

### DIFF
--- a/drivers/usb/host/ohci-hcd.c
+++ b/drivers/usb/host/ohci-hcd.c
@@ -1161,6 +1161,7 @@ static int takeback_td(ohci_t *ohci, td_t *td_list)
 	/* error code of transfer */
 	cc = TD_CC_GET(tdINFO);
 	if (cc) {
+		stat = cc_to_error[cc];
 		if (prev_cc != cc) {
 			/* show same errors only once */
 			err("[%s] USB-error: %s (%x)", __func__, cc_to_string[cc], cc);

--- a/drivers/usb/host/xhci-ring.c
+++ b/drivers/usb/host/xhci-ring.c
@@ -525,7 +525,6 @@ static void abort_td(struct usb_device *udev, int ep_index)
 	union xhci_trb *event;
 	xhci_comp_code comp;
 	trb_type type;
-	u64 addr;
 	u32 field;
 
 	xhci_queue_command(ctrl, NULL, udev->slot_id, ep_index, TRB_STOP_RING);


### PR DESCRIPTION
This PR makes two small fixes in the USB host controller drivers:

 * ohci-hcd.c: Restores the missing stat = cc_to_error[cc]; assignment in takeback_td(), which was accidentally removed in an earlier [commit](https://github.com/vicharak-in/vicharak-linux-u-boot/commit/693f76b3e65320654ae73004d3aaa2fabb159f78#diff-d2d773c9c3afd8f58f05800a3fe70a9766e04ff7e08d265b6904af82e175b615L1075).

  * xhci-ring.c: Removes an unused addr variable from abort_td() to clean up the code and eliminate a compiler warning.