### PR TITLE
console.c: Fixed Support for Ctrl+C to interrupt Autoboot on Vaaman

### DIFF
--- a/common/console.c
+++ b/common/console.c
@@ -707,7 +707,7 @@ int ctrlc_or_q(void)
 				return 1;
 			case 0x03:		/* ^C - Control C */
 				ctrlc_was_pressed = ctrlc_disabled ? ctrlc_was_pressed : 1;
-				return 0;
+				return 1;
 			default:
 				break;
 			}


### PR DESCRIPTION
Fixed the implemented logic of the function `ctrlc_or_q()`, which was previoulsy causing U-Boot to ignore Ctrl+C, leading to the user being unable to interrupt the Autoboot and access the U-Boot console.