### PR TITLE
axon: spl: change boot device order

### DIFF
--- a/arch/arm/dts/rk3588-axon-u-boot.dtsi
+++ b/arch/arm/dts/rk3588-axon-u-boot.dtsi
@@ -15,7 +15,7 @@
 
 	chosen {
 		stdout-path = &uart2;
-		u-boot,spl-boot-order = &sdmmc, &sdhci, &pcie3x4;
+		u-boot,spl-boot-order = &sdhci, &sdmmc, &pcie3x4;
 	};
 
 	secure-otp@fe3a0000 {


### PR DESCRIPTION
Updated rk3588-axon-u-boot.dtsi to change SPL’s U-Boot boot device order. The previous sequence was: SD card →  eMMC →  NVMe. It is now reordered to: eMMC →  SD card →  NVMe, so that SPL prefers onboard eMMC before falling back to external media.